### PR TITLE
Spelling correction in the success callback of the 'delete' command

### DIFF
--- a/UPBot Code/Commands/Delete.cs
+++ b/UPBot Code/Commands/Delete.cs
@@ -54,9 +54,10 @@ public class Delete : BaseCommandModule
         string mentionUserStr = targetUser == null ? string.Empty : $"by {targetUser.DisplayName}";
         string overLimitStr = limitExceeded ? callbackLimitExceeded : string.Empty;
         string messagesLiteral = UtilityFunctions.PluralFormatter(count, "message", "messages");
+        string hasLiteral = UtilityFunctions.PluralFormatter(count, "has", "have");
         
         await ctx.Message.DeleteAsync();
-        await ctx.RespondAsync($"The last {count} {messagesLiteral} {mentionUserStr} have been successfully deleted{overLimitStr}.");
+        await ctx.RespondAsync($"The last {count} {messagesLiteral} '{mentionUserStr}' {hasLiteral} been successfully deleted{overLimitStr}.");
     }
 
     private bool CheckLimit(int count)


### PR DESCRIPTION
- Added "plural-sensitivity"* for the word has/have in the success message of the 'delete' command.

* "plural-sensitivity" means that a word changes based on the count. Example: "message" turns into "messages" if we're talking about several messages.