### PR TITLE
Permission requirements and aliases for 'delete'

### DIFF
--- a/UPBot Code/Commands/Delete.cs
+++ b/UPBot Code/Commands/Delete.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using DSharpPlus;
 using DSharpPlus.CommandsNext;
 using DSharpPlus.CommandsNext.Attributes;
 using DSharpPlus.Entities;
@@ -19,6 +20,9 @@ public class Delete : BaseCommandModule
     /// Delete the last x messages of any user
     /// </summary>
     [Command("delete")]
+    [Aliases("clear", "purge")]
+    [RequirePermissions(Permissions.ManageMessages)] // Restrict this command to users/roles who have the "Manage Messages" permission
+    [RequireRoles(RoleCheckMode.Any, "Helper", "Mod", "Owner")] // Restrict this command to "Helper", "Mod" and "Owner" roles only
     public async Task DeleteCommand(CommandContext ctx, int count)
     {
         if (count <= 0)
@@ -39,6 +43,8 @@ public class Delete : BaseCommandModule
     /// Delete the last x messages of the specified user
     /// </summary>
     [Command("delete")]
+    [RequirePermissions(Permissions.ManageMessages)] // Restrict this command to users/roles who have the "Manage Messages" permission
+    [RequireRoles(RoleCheckMode.Any, "Helper", "Mod", "Owner")] // Restrict this command to "Helper", "Mod" and "Owner" roles only
     public async Task DeleteCommand(CommandContext ctx, DiscordMember targetUser, int count)
     {
         if (count <= 0)


### PR DESCRIPTION
- Added aliases to the 'delete' command, being 'clear' and 'purge'. You can now use the command with these keywords too.
- Added PERMISSION- and ROLE-requirements for the 'delete' command. Only users with the "Manage messages" permission and furthermore, only users with one of the following roles can use this command: "Helper", "Mod", "Owner"