### PR TITLE
Finished Custom Commands

### DIFF
--- a/UPBot Code/Program.cs
+++ b/UPBot Code/Program.cs
@@ -26,8 +26,7 @@ namespace UPBot
             });
             discord.UseInteractivity(new InteractivityConfiguration()
             {
-                PollBehaviour = PollBehaviour.KeepEmojis,
-                Timeout = TimeSpan.FromSeconds(30)
+                Timeout = TimeSpan.FromHours(2)
             });
             CustomCommandsService.DiscordClient = discord;
 

--- a/UPBot Code/UtilityFunctions.cs
+++ b/UPBot Code/UtilityFunctions.cs
@@ -47,7 +47,7 @@ public static class UtilityFunctions
   /// </summary>
   public static string ConstructPath(string fileNameRaw, string fileSuffix)
   {
-    return Path.Combine(AppDomain.CurrentDomain.BaseDirectory, fileNameRaw.Trim().ToLowerInvariant() + fileSuffix);
+    return Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "CustomCommands", fileNameRaw.Trim().ToLowerInvariant() + fileSuffix);
   }
   
   static DiscordEmoji[] emojis;


### PR DESCRIPTION
Generally:
The entire Custom Commands feature works perfectly fine.

'Program.cs':
- Removed PollBehaviour from 'InteractivityConfiguration' construction, because we don't need it (yet?)
- Changes timeout to 2 hours instead of 30 seconds

'UtilityFunctions.cs'
- Changed ConstructPath() to construct the path inside a special folder called "Custom Commands", which is located in the base directory of the executable.
That's what the entire CC feature uses too now (this directory)

'CustomCommandsService.cs'
- Fixed bugs and unexpected behavior
- Simplified code
- Added callbacks for each action (not pretty yet)
- A lot more