### PR TITLE
Added embeds and other error utilities

### DIFF
--- a/UPBot Code/UtilityFunctions.cs
+++ b/UPBot Code/UtilityFunctions.cs
@@ -11,6 +11,13 @@ using System.IO;
 /// </summary>
 public static class UtilityFunctions
 {
+  /// <summary>
+  /// Common colors
+  /// </summary>
+  public static readonly DiscordColor Red = new DiscordColor("#f50f48");
+  public static readonly DiscordColor Green = new DiscordColor("#32a852");
+  
+  // ---------------------------
   static DiscordClient client;
   static DateTimeFormatInfo sortableDateTimeFormat;
 
@@ -49,7 +56,19 @@ public static class UtilityFunctions
   {
     return Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "CustomCommands", fileNameRaw.Trim().ToLowerInvariant() + fileSuffix);
   }
-  
+
+  /// <summary>
+  /// Builds a Discord embed with a given TITLE, DESCRIPTION and COLOR
+  /// </summary>
+  public static DiscordEmbedBuilder BuildEmbed(string title, string description, DiscordColor color)
+  {
+    DiscordEmbedBuilder b = new DiscordEmbedBuilder();
+    b.Title = title;
+    b.Color = color;
+    b.Description = description;
+    return b;
+  }
+
   static DiscordEmoji[] emojis;
   static ulong[] emojiIDs;
   static DiscordEmoji thinkingAsError;
@@ -111,5 +130,11 @@ public enum EmojiEnum {
   UnitedProgramming = 9,
   Unity = 10,
   Godot = 11,
-  AutoRrefactored = 12,
+  AutoRefactored = 12,
+}
+
+public enum CommandErrors
+{
+    InvalidParams,
+    InvalidParamsDelete
 }


### PR DESCRIPTION
- Added embeds as callbacks, instead of plain messages. For following commands/functionalities:
Delete and all Custom Commands (yet coming)
- Added a Utility Function in 'UtilityFunctions.cs', which is responsible for building an embed with a given title, description and color.
- Added common colors as static readonly colors in 'UtilityFunctions.cs'
- Added 'CommandError' enum to identify an error
- Added error method in 'Delete.cs' to deal with errors and build different embeds for different errors (identified with 'CommandError' enum)
- Fixed indentation of 'Delete.cs'