### PR TITLE
Delete certain bot callbacks automatically after x seconds

### DIFF
--- a/UPBot Code/Commands/Delete.cs
+++ b/UPBot Code/Commands/Delete.cs
@@ -88,9 +88,11 @@ public class Delete : BaseCommandModule
         string hasLiteral = UtilityFunctions.PluralFormatter(count, "has", "have");
 
         await ctx.Message.DeleteAsync();
-        string message = $"The last {count} {messagesLiteral} {mentionUserStr} {hasLiteral} been successfully deleted{overLimitStr}.";
+        string embedMessage = $"The last {count} {messagesLiteral} {mentionUserStr} {hasLiteral} been successfully deleted{overLimitStr}.";
 
-        await UtilityFunctions.BuildEmbedAndExecute("Success", message, UtilityFunctions.Green, ctx, true);
+        var message = await UtilityFunctions.BuildEmbedAndExecute("Success", embedMessage, UtilityFunctions.Green, ctx, true);
+        await Task.Delay(10_000);
+        await message.DeleteAsync();
     }
 
     private async Task ErrorCallback(CommandErrors error, CommandContext ctx, params object[] additionalParams)
@@ -99,7 +101,7 @@ public class Delete : BaseCommandModule
         switch (error)
         {
             case CommandErrors.InvalidParams:
-                message = $"Invalid params for the command {ctx.Command.Name}.";
+                message = $"Invalid params for the command {ctx?.Command.Name}.";
                 break;
             case CommandErrors.InvalidParamsDelete:
                 if (additionalParams[0] is int count)

--- a/UPBot Code/UtilityFunctions.cs
+++ b/UPBot Code/UtilityFunctions.cs
@@ -19,15 +19,15 @@ public static class UtilityFunctions
   public static readonly DiscordColor Green = new DiscordColor("#32a852");
   public static readonly DiscordColor LightBlue = new DiscordColor("#34cceb");
   
-  // ---------------------------
-  static DiscordClient client;
-  static DateTimeFormatInfo sortableDateTimeFormat;
-  static StreamWriter logs;
+  // Fields relevant for InitClient()
+  private static DiscordClient client;
+  private static DateTimeFormatInfo sortableDateTimeFormat;
+  private static StreamWriter logs;
 
   public static void InitClient(DiscordClient c) {
     client = c;
     thinkingAsError = DiscordEmoji.FromUnicode("🤔");
-    emojiIDs = new ulong[] {
+    emojiIDs = new [] {
       830907665869570088ul, // OK = 0,
       830907684085039124ul, // KO = 1,
       840702597216337990ul, // whatthisguysaid = 2,
@@ -94,13 +94,11 @@ public static class UtilityFunctions
   /// <param name="color">Embed color</param>
   /// <param name="ctx">CommandContext, required to send a message</param>
   /// <param name="respond">Respond to original message or send an independent message?</param>
-  public static async Task<DiscordEmbedBuilder> BuildEmbedAndExecute(string title, string description, DiscordColor color, 
+  public static async Task<DiscordMessage> BuildEmbedAndExecute(string title, string description, DiscordColor color, 
     CommandContext ctx, bool respond)
   {
     var embedBuilder = BuildEmbed(title, description, color);
-    await LogEmbed(embedBuilder, ctx, respond);
-    
-    return embedBuilder;
+    return await LogEmbed(embedBuilder, ctx, respond);
   }
 
   /// <summary>
@@ -109,20 +107,17 @@ public static class UtilityFunctions
   /// <param name="builder">Embed builder with the embed template</param>
   /// <param name="ctx">CommandContext, required to send a message</param>
   /// <param name="respond">Respond to original message or send an independent message?</param>
-  public static async Task LogEmbed(DiscordEmbedBuilder builder, CommandContext ctx, bool respond)
+  public static async Task<DiscordMessage> LogEmbed(DiscordEmbedBuilder builder, CommandContext ctx, bool respond)
   {
     if (respond)
-    {
-      await ctx.RespondAsync(builder.Build());
-      return;
-    }
+      return await ctx.RespondAsync(builder.Build());
 
-    await ctx.Channel.SendMessageAsync(builder.Build());
+    return await ctx.Channel.SendMessageAsync(builder.Build());
   } 
 
-  static DiscordEmoji[] emojis;
-  static ulong[] emojiIDs;
-  static DiscordEmoji thinkingAsError;
+  private static DiscordEmoji[] emojis;
+  private static ulong[] emojiIDs;
+  private static DiscordEmoji thinkingAsError;
 
   /// <summary>
   /// This function gets the Emoji object corresponding to the emojis of the server.


### PR DESCRIPTION
- Changed utility functions responsible for building and sending an embed to return the 'DiscordMessage' instance, so it can be used as a return type.
- Related to the point above, with this returned instance, I can easily delete this message after x seconds using Task.Delay() and `message`.DeleteAsync()

Added deletion after x seconds for following callbacks:
- Success callback when deleting a message ('delete' command)