### PR TITLE
Added flexible directory name to 'ConstructPath' function

### DIFF
--- a/UPBot Code/Commands/BannedWords.cs
+++ b/UPBot Code/Commands/BannedWords.cs
@@ -18,9 +18,10 @@ public class BannedWords : BaseCommandModule {
   private static List<BannedWord> bannedWords = null;
   private static Regex valid = new Regex(@"^[a-zA-Z0-9]+$");
   private static Regex letters = new Regex(@"[a-zA-Z0-9]");
+  private const string directoryName = "Restrictions";
 
   public static void Init() {
-    string path = UtilityFunctions.ConstructPath("BannedWords", ".txt");
+    string path = UtilityFunctions.ConstructPath(directoryName, "BannedWords", ".txt");
     if (!File.Exists(path)) return;
     string[] all = File.ReadAllLines(path);
     bannedWords = new List<BannedWord>();
@@ -121,7 +122,7 @@ public class BannedWords : BaseCommandModule {
   }
 
   void SaveWord(BannedWord w) {
-    string path = UtilityFunctions.ConstructPath("BannedWords", ".txt");
+    string path = UtilityFunctions.ConstructPath(directoryName, "BannedWords", ".txt");
     if (!File.Exists(path)) File.CreateText(path);
     try {
       using (StreamWriter sw = File.AppendText(path)) {
@@ -133,7 +134,7 @@ public class BannedWords : BaseCommandModule {
   }
 
   void SaveList() {
-    string path = UtilityFunctions.ConstructPath("BannedWords", ".txt");
+    string path = UtilityFunctions.ConstructPath(directoryName, "BannedWords", ".txt");
     if (File.Exists(path)) {
       try {
         File.Delete(path);

--- a/UPBot Code/Commands/CustomCommand.cs
+++ b/UPBot Code/Commands/CustomCommand.cs
@@ -10,7 +10,7 @@ public class CustomCommand
     public CustomCommand(string[] names, string content)
     {
         this.Names = names;
-        this.FilePath = UtilityFunctions.ConstructPath(names[0], ".txt");
+        this.FilePath = UtilityFunctions.ConstructPath(CustomCommandsService.DirectoryNameCC, names[0], ".txt");
         this.Content = content;
     }
     

--- a/UPBot Code/Commands/CustomCommandsService.cs
+++ b/UPBot Code/Commands/CustomCommandsService.cs
@@ -17,6 +17,7 @@ public class CustomCommandsService : BaseCommandModule
 {
     private static readonly List<CustomCommand> Commands = new List<CustomCommand>();
     internal static DiscordClient DiscordClient { get; set; }
+    internal const string DirectoryNameCC = "CustomCommands";
 
     [Command("newcc")]
     [Aliases("createcc", "addcc", "ccadd", "cccreate")]
@@ -55,7 +56,7 @@ public class CustomCommandsService : BaseCommandModule
     [RequireRoles(RoleCheckMode.Any, "Mod", "Owner")] // Restrict access to users with the "Mod" or "Owner" role only
     public async Task DeleteCommand(CommandContext ctx, string name)
     {
-        string filePath = UtilityFunctions.ConstructPath(name, ".txt");
+        string filePath = UtilityFunctions.ConstructPath(DirectoryNameCC, name, ".txt");
         if (File.Exists(filePath))
         {
             File.Delete(filePath);
@@ -72,7 +73,7 @@ public class CustomCommandsService : BaseCommandModule
     [RequireRoles(RoleCheckMode.Any, "Mod", "Owner")] // Restrict access to users with the "Mod" or "Owner" role only
     public async Task EditCommand(CommandContext ctx, string name)
     {
-        string filePath = UtilityFunctions.ConstructPath(name, ".txt");
+        string filePath = UtilityFunctions.ConstructPath(DirectoryNameCC, name, ".txt");
         if (File.Exists(filePath))
         {
             string content = await WaitForContent(ctx, name);

--- a/UPBot Code/UtilityFunctions.cs
+++ b/UPBot Code/UtilityFunctions.cs
@@ -43,7 +43,7 @@ public static class UtilityFunctions
       876180793213464606ul  // AutoRefactored = 12,
     };
     sortableDateTimeFormat = CultureInfo.GetCultureInfo("en-US").DateTimeFormat;
-    string logPath = ConstructPath("BotLogs " + DateTime.Now.ToString("yyyyMMdd"), ".logs");
+    string logPath = ConstructPath("Logs", "BotLogs " + DateTime.Now.ToString("yyyyMMdd"), ".logs");
     if (File.Exists(logPath)) logs = new StreamWriter(logPath, append: true);
     else logs = File.CreateText(logPath);
   }
@@ -64,9 +64,12 @@ public static class UtilityFunctions
   /// with a given raw file name and the fileSuffix (file type)
   /// NOTE: The file suffix must contain a period (e.g. ".txt" or ".png")
   /// </summary>
-  public static string ConstructPath(string fileNameRaw, string fileSuffix)
+  /// <param name="directoryName">The name of the final folder, in which the file will be saved</param>
+  /// <param name="fileNameRaw">The name of the file (without file type)</param>
+  /// <param name="fileSuffix">The file-suffix (file-type, e.g. ".txt" or ".png")</param>
+  public static string ConstructPath(string directoryName, string fileNameRaw, string fileSuffix)
   {
-    return Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "CustomCommands", fileNameRaw.Trim().ToLowerInvariant() + fileSuffix);
+    return Path.Combine(AppDomain.CurrentDomain.BaseDirectory, directoryName, fileNameRaw.Trim().ToLowerInvariant() + fileSuffix);
   }
 
   /// <summary>


### PR DESCRIPTION
Added flexible directory name to 'ConstructPath' function and changed all references to it

- Added the ability to specify the final directory name, you want to use for the file, when calling the 'ConstructPath' function in 'UtilityFunctions'. For further information, please refer to the summary and read this commit carefully.
- Changed all references to this function to include this directoryName. For that, I added two constant strings for 'BannedWords.cs' and 'CustomCommandService.cs' ('CustomCommand.cs' shares string with the mentioned class). The occurrence in 'UtilityFunctions.cs' uses a hard-coded literal.