### PR TITLE
Added description to 'delete' and all CC commands

### DIFF
--- a/UPBot Code/Commands/CustomCommandsService.cs
+++ b/UPBot Code/Commands/CustomCommandsService.cs
@@ -21,6 +21,11 @@ public class CustomCommandsService : BaseCommandModule
 
     [Command("newcc")]
     [Aliases("createcc", "addcc", "ccadd", "cccreate")]
+    [Description("**Create** a new Custom Command (so-called 'CC') with a specified name and all aliases if desired " +
+                 "(no duplicate alias allowed).\nAfter doing this, the bot will ask you to input the content, which will " +
+                 "be displayed once someone invokes this CC. Your entire next message will be used for the content, so " +
+                 "be careful what you type!\n\n**Usage:**\n\n- `newcc name` (without alias)\n-`newcc name alias1 alias2`" +
+                 " (with 2 aliases)")]
     [RequireRoles(RoleCheckMode.Any, "Mod", "Owner")] // Restrict access to users with the "Mod" or "Owner" role only
     public async Task CreateCommand(CommandContext ctx, params string[] names)
     {
@@ -53,6 +58,8 @@ public class CustomCommandsService : BaseCommandModule
 
     [Command("delcc")]
     [Aliases("deletecc", "removecc")]
+    [Description("**Delete** a Custom Command (so-called 'CC').\n**Attention!** Use the main name of the CC " +
+                 "you entered first when you created it, **not an alias!**\nThe CC will be irrevocably deleted.")]
     [RequireRoles(RoleCheckMode.Any, "Mod", "Owner")] // Restrict access to users with the "Mod" or "Owner" role only
     public async Task DeleteCommand(CommandContext ctx, string name)
     {
@@ -70,6 +77,8 @@ public class CustomCommandsService : BaseCommandModule
 
     [Command("editcc")]
     [Aliases("ccedit")]
+    [Description("**Edit** the **content** of a Custom Command (so-called 'CC')." +
+                 "\n**Attention!** Use the main name of the CC you entered first when you created it, **not an alias!**")]
     [RequireRoles(RoleCheckMode.Any, "Mod", "Owner")] // Restrict access to users with the "Mod" or "Owner" role only
     public async Task EditCommand(CommandContext ctx, string name)
     {

--- a/UPBot Code/Commands/Delete.cs
+++ b/UPBot Code/Commands/Delete.cs
@@ -21,6 +21,9 @@ public class Delete : BaseCommandModule
     /// </summary>
     [Command("delete")]
     [Aliases("clear", "purge")]
+    [Description("Deletes the last x messages in the channel, the command was invoked in (e.g. `\\delete 10`)." +
+                 "\nIt contains an overload to delete the last x messages of a specified user (e.g. `\\delete @User 10`)." +
+                 "\nThis command can only be invoked by a Helper or Mod.")]
     [RequirePermissions(Permissions.ManageMessages)] // Restrict this command to users/roles who have the "Manage Messages" permission
     [RequireRoles(RoleCheckMode.Any, "Helper", "Mod", "Owner")] // Restrict this command to "Helper", "Mod" and "Owner" roles only
     public async Task DeleteCommand(CommandContext ctx, int count)


### PR DESCRIPTION
- Added descriptions to the 'delete' and all CC commands ('newcc', 'delcc', 'editcc'), which will be used when someone invokes the \help command for one of these.