### PR TITLE
Bugfix: Accessed directory, that didn't exist

### DIFF
--- a/UPBot Code/Commands/CustomCommandsService.cs
+++ b/UPBot Code/Commands/CustomCommandsService.cs
@@ -103,7 +103,7 @@ public class CustomCommandsService : BaseCommandModule
                 command.EditCommand(content);
 
             string embedMessage = $"CC **{name}** successfully edited!";
-            await  UtilityFunctions.BuildEmbedAndExecute("Success", embedMessage, UtilityFunctions.Green, ctx, false);
+            await UtilityFunctions.BuildEmbedAndExecute("Success", embedMessage, UtilityFunctions.Green, ctx, false);
         }
         else
         {

--- a/UPBot Code/UtilityFunctions.cs
+++ b/UPBot Code/UtilityFunctions.cs
@@ -69,7 +69,11 @@ public static class UtilityFunctions
   /// <param name="fileSuffix">The file-suffix (file-type, e.g. ".txt" or ".png")</param>
   public static string ConstructPath(string directoryName, string fileNameRaw, string fileSuffix)
   {
-    return Path.Combine(AppDomain.CurrentDomain.BaseDirectory, directoryName, fileNameRaw.Trim().ToLowerInvariant() + fileSuffix);
+    string directoryPath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, directoryName);
+    if (!Directory.Exists(Path.Combine(directoryPath)))
+      Directory.CreateDirectory(directoryPath);
+    
+    return Path.Combine(directoryPath, fileNameRaw.Trim().ToLowerInvariant() + fileSuffix);
   }
 
   /// <summary>


### PR DESCRIPTION
- In one of the previous commits, I added the ability to define the final directory/ies (folder/s), the file should be found/created in, when calling the 'ConstructPath' function in 'UtilityFunctions.cs'. However, there was no check if the directory exists. Now, I added this into the function itself, so it creates the directory if it didn't exist already.
- Removed redundant space in 'CustomCommandsService.cs'