### PR TITLE
Small changes to avoid warnings and possible optimization for CC

### DIFF
--- a/UPBot Code/Commands/BannedWords.cs
+++ b/UPBot Code/Commands/BannedWords.cs
@@ -196,7 +196,7 @@ public class BannedWords : BaseCommandModule {
     return await ctx.Client.GetUserAsync(userId);
   }
 
-  internal static async void CheckMessage(DiscordClient client, MessageCreateEventArgs args) {
+  internal static async Task CheckMessage(DiscordClient client, MessageCreateEventArgs args) {
     // Who is the author? If the bot or a mod then ignore
     if (args.Author.Equals(client.CurrentUser)) return;
     DiscordUser user = args.Author;

--- a/UPBot Code/Commands/CustomCommandsService.cs
+++ b/UPBot Code/Commands/CustomCommandsService.cs
@@ -118,7 +118,7 @@ public class CustomCommandsService : BaseCommandModule
         if (!Directory.Exists(path))
             Directory.CreateDirectory(path);
 
-        foreach (string fileName in Directory.GetFiles(System.AppDomain.CurrentDomain.BaseDirectory))
+        foreach (string fileName in Directory.GetFiles(path))
         {
             using (StreamReader sr = File.OpenText(fileName))
             {

--- a/UPBot Code/Program.cs
+++ b/UPBot Code/Program.cs
@@ -31,7 +31,7 @@ namespace UPBot {
       commands.RegisterCommands(Assembly.GetExecutingAssembly()); // Registers all defined commands
 
       BannedWords.Init();
-      discord.MessageCreated += async (s, e) => { BannedWords.CheckMessage(s, e); };
+      discord.MessageCreated += async (s, e) => { await BannedWords.CheckMessage(s, e); };
 
       discord.GuildMemberAdded += MembersTracking.DiscordMemberAdded;
       discord.GuildMemberRemoved += MembersTracking.DiscordMemberRemoved;


### PR DESCRIPTION
- Previously, the 'LoadCustomCommands()' function loaded all files in the base directory. Now, it only considers the 'CustomCommands' folder inside.
- Avoid warning by changing `async void` to `async Task` and `awaiting` the function call in 'Program.cs' (the function is located in 'BannedWords.cs')