### PR TITLE
Bugfix 'delete @user x' and fixed typo

### DIFF
--- a/UPBot Code/Commands/Delete.cs
+++ b/UPBot Code/Commands/Delete.cs
@@ -61,7 +61,7 @@ public class Delete : BaseCommandModule
         bool limitExceeded = CheckLimit(count);
 
         var allMessages = ctx.Channel.GetMessagesAsync().Result; // Get last 100 messages
-        var userMessages = allMessages.Where(x => x.Author == targetUser).Take(count);
+        var userMessages = allMessages.Where(x => x.Author == targetUser).Take(count + 1);
         await DeleteMessages(ctx, userMessages);
 
         await Success(ctx, limitExceeded, count, targetUser);

--- a/UPBot Code/Commands/WhoIs.cs
+++ b/UPBot Code/Commands/WhoIs.cs
@@ -63,7 +63,7 @@ public class WhoIs : BaseCommandModule {
     if (m.PremiumSince != null) {
       DateTimeOffset bdate = ((DateTimeOffset)m.PremiumSince).UtcDateTime;
       string booster = bdate.Year + "/" + bdate.Month + "/" + bdate.Day;
-      embed.AddField("Booster", "Form " + booster, true);
+      embed.AddField("Booster", "From " + booster, true);
     }
     if (m.Flags != null) embed.AddField("Flags", m.Flags.ToString(), true); // Only the default flags will be shown. This bot will not be very diffused so probably we do not need specific checks for flags
 


### PR DESCRIPTION
- Executing the command, which is supposed to delete the last x messages of a specified user deleted the last x - 1 messages, unlike the normal 'delete' command without specifying a user. This has been fixed!
- Fixed typo in 'whois' command (booster "Form" to "From")