### PR TITLE
Edit CC names

### DIFF
--- a/UPBot Code/Commands/CustomCommandsService.cs
+++ b/UPBot Code/Commands/CustomCommandsService.cs
@@ -27,13 +27,13 @@ public class CustomCommandsService : BaseCommandModule
                  "be careful what you type!\n\n**Usage:**\n\n- `newcc name` (without alias)\n- `newcc name alias1 alias2`" +
                  " (with 2 aliases)\n\nThis command can only be invoked by a Mod.")]
     [RequireRoles(RoleCheckMode.Any, "Mod", "Owner")] // Restrict access to users with the "Mod" or "Owner" role only
-    public async Task CreateCommand(CommandContext ctx, params string[] names)
+    public async Task CreateCommand(CommandContext ctx, [Description("A 'list' of all aliases. The first term is the **main name**, the other ones, separated by a space, are aliases")] params string[] names)
     {
         foreach (var name in names)
         {
             if (DiscordClient.GetCommandsNext().RegisteredCommands.ContainsKey(name)) // Check if there is a command with one of the names already
             {
-                await ErrorCallback(CommandErrors.CommandExists, ctx, name);
+                await UtilityFunctions.ErrorCallback(CommandErrors.CommandExists, ctx, name);
                 return;
             }
             
@@ -41,7 +41,7 @@ public class CustomCommandsService : BaseCommandModule
             {
                 if (cmd.Names.Contains(name)) // Check if there is already a CC with one of the names
                 {
-                    await ErrorCallback(CommandErrors.CommandExists, ctx, name);
+                    await UtilityFunctions.ErrorCallback(CommandErrors.CommandExists, ctx, name);
                     return;
                 }
             }
@@ -56,13 +56,13 @@ public class CustomCommandsService : BaseCommandModule
         await UtilityFunctions.BuildEmbedAndExecute("Success", embedMessage, UtilityFunctions.Green, ctx, false);
     }
 
-    [Command("delcc")]
-    [Aliases("deletecc", "removecc")]
+    [Command("ccdel")]
+    [Aliases("ccdelete", "ccremove", "delcc", "deletecc", "removecc")]
     [Description("**Delete** a Custom Command (so-called 'CC').\n**Attention!** Use the main name of the CC " +
                  "you entered first when you created it, **not an alias!**\nThe CC will be irrevocably deleted." +
                  "\n\nThis command can only be invoked by a Mod.")]
     [RequireRoles(RoleCheckMode.Any, "Mod", "Owner")] // Restrict access to users with the "Mod" or "Owner" role only
-    public async Task DeleteCommand(CommandContext ctx, string name)
+    public async Task DeleteCommand(CommandContext ctx, [Description("Main name of the CC you want to delete")] string name)
     {
         string filePath = UtilityFunctions.ConstructPath(DirectoryNameCC, name, ".txt");
         if (File.Exists(filePath))
@@ -76,13 +76,13 @@ public class CustomCommandsService : BaseCommandModule
         }
     }
 
-    [Command("editcc")]
-    [Aliases("ccedit")]
+    [Command("ccedit")]
+    [Aliases("editcc")]
     [Description("**Edit** the **content** of a Custom Command (so-called 'CC')." +
                  "\n**Attention!** Use the main name of the CC you entered first when you created it, **not an alias!**" +
                  "\n\nThis command can only be invoked by a Mod.")]
     [RequireRoles(RoleCheckMode.Any, "Mod", "Owner")] // Restrict access to users with the "Mod" or "Owner" role only
-    public async Task EditCommand(CommandContext ctx, string name)
+    public async Task EditCommand(CommandContext ctx, [Description("Main name of the CC you want to edit")] string name)
     {
         string filePath = UtilityFunctions.ConstructPath(DirectoryNameCC, name, ".txt");
         if (File.Exists(filePath))
@@ -106,10 +106,54 @@ public class CustomCommandsService : BaseCommandModule
             await UtilityFunctions.BuildEmbedAndExecute("Success", embedMessage, UtilityFunctions.Green, ctx, false);
         }
         else
+            await UtilityFunctions.ErrorCallback(CommandErrors.MissingCommand, ctx);
+    }
+
+    [Command("cceditname")]
+    [Aliases("ccnameedit", "editnamecc")]
+    [Description("**Edit** the **names** (including aliases) of an existing CC." +
+                 "\n**Attention!** Use the main name of the CC you entered first when you created it, **not an alias!**" +
+                 "\n\nThis command can only be invoked by a Mod.")]
+    [RequireRoles(RoleCheckMode.Any, "Mod", "Owner")] // Restrict access to users with the "Mod" or "Owner" role only
+    public async Task EditCommandName(CommandContext ctx, [Description("A list of new names and aliases, " +
+                                                                       "__**BUT**__ the **FIRST** term is the current **main name** " +
+                                                                       "of the CC whose name you want to edit, the **SECOND** term " +
+                                                                       "is the new **main name** and all the other terms are new aliases")] params string[] names)
+    {
+        if (names.Length < 2)
         {
-            string embedMessage = "There is no Custom Command with this name! Please don't use an alias, use the original name!";
-            await UtilityFunctions.BuildEmbedAndExecute("Error", embedMessage, UtilityFunctions.Red, ctx, true);
+            await UtilityFunctions.ErrorCallback(CommandErrors.InvalidParams, ctx);
+            return;
         }
+        
+        string filePath = UtilityFunctions.ConstructPath(DirectoryNameCC, names[0], ".txt");
+        if (File.Exists(filePath))
+        {
+            if (TryGetCommand(names[0], out CustomCommand command))
+                command.EditCommand(names.Skip(1).ToArray());
+            
+            string content = string.Empty;
+            using (StreamReader sr = File.OpenText(filePath))
+            {
+                string c;
+                await sr.ReadLineAsync();
+                while ((c = await sr.ReadLineAsync()) != null)
+                    content += c + System.Environment.NewLine;
+            }
+
+            string newPath = UtilityFunctions.ConstructPath(DirectoryNameCC, names[1], ".txt");
+            File.Move(filePath, newPath);
+            using (StreamWriter sw = File.CreateText(newPath))
+            {
+                await sw.WriteLineAsync(string.Join(',', names.Skip(1)));
+                await sw.WriteLineAsync(content);
+            }
+
+            string embedDescription = "The CC names have been successfully edited.";
+            await UtilityFunctions.BuildEmbedAndExecute("Success", embedDescription, UtilityFunctions.Green, ctx, false);
+        }
+        else
+            await UtilityFunctions.ErrorCallback(CommandErrors.MissingCommand, ctx);
     }
 
     [Command("cclist")]
@@ -119,7 +163,7 @@ public class CustomCommandsService : BaseCommandModule
     {
         if (Commands.Count <= 0)
         {
-            await ErrorCallback(CommandErrors.UnknownError, ctx);
+            await UtilityFunctions.ErrorCallback(CommandErrors.NoCustomCommands, ctx);
             return;
         }
 
@@ -177,25 +221,6 @@ public class CustomCommandsService : BaseCommandModule
                 await sw.WriteLineAsync(string.Join(',', command.Names));
                 await sw.WriteLineAsync(command.Content);
             }
-        }
-    }
-
-    private async Task ErrorCallback(CommandErrors error, CommandContext ctx, params object[] additionalParams)
-    {
-        switch (error)
-        {
-            case CommandErrors.CommandExists:
-                if (additionalParams[0] is string name)
-                {
-                    string message = $"There is already a command containing the alias {additionalParams[0]}";
-                    await UtilityFunctions.BuildEmbedAndExecute("Error", message, UtilityFunctions.Red, ctx, true);
-                }
-                else
-                    throw new System.ArgumentException("This error type 'CommandErrors.CommandExists' requires a string");
-                break;
-            case CommandErrors.UnknownError:
-                await UtilityFunctions.BuildEmbedAndExecute("Error", "Unknown error!", UtilityFunctions.Red, ctx, false);
-                break;
         }
     }
 

--- a/UPBot Code/Commands/Delete.cs
+++ b/UPBot Code/Commands/Delete.cs
@@ -26,12 +26,12 @@ public class Delete : BaseCommandModule
                  "\nThis command can only be invoked by a Helper or Mod.")]
     [RequirePermissions(Permissions.ManageMessages)] // Restrict this command to users/roles who have the "Manage Messages" permission
     [RequireRoles(RoleCheckMode.Any, "Helper", "Mod", "Owner")] // Restrict this command to "Helper", "Mod" and "Owner" roles only
-    public async Task DeleteCommand(CommandContext ctx, int count)
+    public async Task DeleteCommand(CommandContext ctx, [Description("How many messages should be deleted?")] int count)
     {
         UtilityFunctions.LogUserCommand(ctx);
         if (count <= 0)
         {
-            await ErrorCallback(CommandErrors.InvalidParamsDelete, ctx, count);
+            await UtilityFunctions.ErrorCallback(CommandErrors.InvalidParamsDelete, ctx, count);
             return;
         }
 
@@ -49,12 +49,13 @@ public class Delete : BaseCommandModule
     [Command("delete")]
     [RequirePermissions(Permissions.ManageMessages)] // Restrict this command to users/roles who have the "Manage Messages" permission
     [RequireRoles(RoleCheckMode.Any, "Helper", "Mod", "Owner")] // Restrict this command to "Helper", "Mod" and "Owner" roles only
-    public async Task DeleteCommand(CommandContext ctx, DiscordMember targetUser, int count)
+    public async Task DeleteCommand(CommandContext ctx, [Description("Whose last x messages should get deleted?")]DiscordMember targetUser, 
+        [Description("How many messages should get deleted?")] int count)
     {
         UtilityFunctions.LogUserCommand(ctx);
         if (count <= 0)
         {
-            await ErrorCallback(CommandErrors.InvalidParamsDelete, ctx, count);
+            await UtilityFunctions.ErrorCallback(CommandErrors.InvalidParamsDelete, ctx, count);
             return;
         }
 
@@ -96,24 +97,6 @@ public class Delete : BaseCommandModule
         var message = await UtilityFunctions.BuildEmbedAndExecute("Success", embedMessage, UtilityFunctions.Green, ctx, true);
         await Task.Delay(10_000);
         await message.DeleteAsync();
-    }
-
-    private async Task ErrorCallback(CommandErrors error, CommandContext ctx, params object[] additionalParams)
-    {
-        string message = string.Empty;
-        switch (error)
-        {
-            case CommandErrors.InvalidParams:
-                message = $"Invalid params for the command {ctx?.Command.Name}.";
-                break;
-            case CommandErrors.InvalidParamsDelete:
-                if (additionalParams[0] is int count)
-                    message = $"You can't delete {count} messages. Try to eat {count} apples, does that make sense?";
-                else
-                    goto case CommandErrors.InvalidParams;
-                break;
-        }
-        await UtilityFunctions.BuildEmbedAndExecute("Error", message, UtilityFunctions.Red, ctx, true);
     }
 
     private bool CheckLimit(int count)

--- a/UPBot Code/UtilityFunctions.cs
+++ b/UPBot Code/UtilityFunctions.cs
@@ -193,6 +193,47 @@ public static class UtilityFunctions
       string m = e.Message;
     }
   }
+  
+  internal static async Task ErrorCallback(CommandErrors error, CommandContext ctx, params object[] additionalParams)
+  {
+    DiscordColor red = UtilityFunctions.Red;
+    string message = string.Empty;
+    bool respond = false;
+    switch (error)
+    {
+      case CommandErrors.CommandExists:
+        respond = true;
+        if (additionalParams[0] is string name)
+          message = $"There is already a command containing the alias {additionalParams[0]}";
+        else
+          throw new System.ArgumentException("This error type 'CommandErrors.CommandExists' requires a string");
+        break;
+      case CommandErrors.UnknownError:
+        message = "Unknown error!";
+        respond = false;
+        break;
+      case CommandErrors.InvalidParams:
+        message = "The given parameters are invalid. Enter \\help [commandName] to get help with the usage of the command.";
+        respond = true;
+        break;
+      case CommandErrors.InvalidParamsDelete:
+        if (additionalParams[0] is int count)
+          message = $"You can't delete {count} messages. Try to eat {count} apples, does that make sense?";
+        else
+          goto case CommandErrors.InvalidParams;
+        break;
+      case CommandErrors.MissingCommand:
+        message = "There is no command with this name! If it's a CC, please don't use an alias, use the original name!";
+        respond = true;
+        break;
+      case CommandErrors.NoCustomCommands:
+        message = "There are no CC's currently.";
+        respond = false;
+        break;
+    }
+        
+    await UtilityFunctions.BuildEmbedAndExecute("Error", message, red, ctx, respond);
+  }
 }
 
 public enum EmojiEnum {
@@ -217,5 +258,7 @@ public enum CommandErrors
     InvalidParams,
     InvalidParamsDelete,
     CommandExists,
-    UnknownError
+    UnknownError,
+    MissingCommand,
+    NoCustomCommands
 }


### PR DESCRIPTION
- You can now, not only edit the content of a CC, but also edit the name and aliases of a CC. Use the `cceditname` (or an alias) command for that:
`cceditname oldMainName newMainName aliasesIfDesired`
- Changed main command names for CC's to start with CC (instead of 'deletecc', the main name is 'ccdelete' now for example), but the aliases are still there. I also added a few more aliases to one or another command.
- The 'ErrorCallback' function is now global for every error and command (in 'UtilityFunctions'). The error feedbacks are defined only once, in this static function.
- Improved the 'ErrorCallback' function to increase readability
- Added description to each parameter (for \help command)
- Added two new errors ("MissingCommand" and "NoCustomCommands")