### PR TITLE
🔨 Add invariant property on csproj

### DIFF
--- a/UPBot.csproj
+++ b/UPBot.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp3.1</TargetFramework>
+    <InvariantGlobalization>true</InvariantGlobalization>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
* Some recent changes to libicu caused the bot to crash
* We weren't able to trace specific source of the issue
* We don't need globalization, so just turning it off